### PR TITLE
[8.2] - Fix CVE-2023-3354

### DIFF
--- a/SOURCES/qemu-4.2.1-CVE-2023-3354.backport.patch
+++ b/SOURCES/qemu-4.2.1-CVE-2023-3354.backport.patch
@@ -1,0 +1,83 @@
+io: remove io watch if TLS channel is closed during handshake
+
+The TLS handshake make take some time to complete, during which time an
+I/O watch might be registered with the main loop. If the owner of the
+I/O channel invokes qio_channel_close() while the handshake is waiting
+to continue the I/O watch must be removed. Failing to remove it will
+later trigger the completion callback which the owner is not expecting
+to receive. In the case of the VNC server, this results in a SEGV as
+vnc_disconnect_start() tries to shutdown a client connection that is
+already gone / NULL.
+
+CVE-2023-3354
+Reported-by: jiangyegen <jiangyegen@huawei.com>
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+Backported-by: Lucas Ravagnier <lucas.ravagnier@vates.tech>
+---
+
+In v2:
+
+ - Use g_clear_handle_id to set source ID to zero
+
+ include/io/channel-tls.h |  1 +
+ io/channel-tls.c         | 18 ++++++++++++------
+ 2 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/include/io/channel-tls.h b/include/io/channel-tls.h
+index 5672479e9e..26c67f17e2 100644
+--- a/include/io/channel-tls.h
++++ b/include/io/channel-tls.h
+@@ -48,6 +48,7 @@ struct QIOChannelTLS {
+     QIOChannel *master;
+     QCryptoTLSSession *session;
+     QIOChannelShutdown shutdown;
++    guint hs_ioc_tag;
+ };
+ 
+ /**
+diff --git a/io/channel-tls.c b/io/channel-tls.c
+index 9805dd0a3f..847d5297c3 100644
+--- a/io/channel-tls.c
++++ b/io/channel-tls.c
+@@ -198,12 +198,13 @@ static void qio_channel_tls_handshake_task(QIOChannelTLS *ioc,
+         }
+ 
+         trace_qio_channel_tls_handshake_pending(ioc, status);
+-        qio_channel_add_watch_full(ioc->master,
+-                                   condition,
+-                                   qio_channel_tls_handshake_io,
+-                                   data,
+-                                   NULL,
+-                                   context);
++        ioc->hs_ioc_tag =
++            qio_channel_add_watch_full(ioc->master,
++                                       condition,
++                                       qio_channel_tls_handshake_io,
++                                       data,
++                                       NULL,
++                                       context);
+     }
+ }
+ 
+@@ -218,6 +219,7 @@ static gboolean qio_channel_tls_handshake_io(QIOChannel *ioc,
+     QIOChannelTLS *tioc = QIO_CHANNEL_TLS(
+         qio_task_get_source(task));
+ 
++    tioc->hs_ioc_tag = 0;
+     g_free(data);
+     qio_channel_tls_handshake_task(tioc, task, context);
+ }
+@@ -378,6 +380,11 @@ static int qio_channel_tls_close(QIOChannel *ioc,
+ {
+     QIOChannelTLS *tioc = QIO_CHANNEL_TLS(ioc);
+ 
++    if (tioc->hs_ioc_tag) {
++        g_source_remove(tioc->hs_ioc_tag);
++        tioc->hs_ioc_tag = 0;
++    }
++
+     return qio_channel_close(tioc->master, errp);
+ }
+  
+-- 
+2.41.0

--- a/SPECS/qemu.spec
+++ b/SPECS/qemu.spec
@@ -15,7 +15,7 @@ Summary: qemu-dm device model
 Name: qemu
 Epoch: 2
 Version: 4.2.1
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPL
 Requires: xcp-clipboardd
 Requires: xengt-userspace
@@ -113,6 +113,9 @@ Patch84: add-an-ide-read-cache.patch
 Patch85: disable-dirty-vram-tracking.patch
 Patch86: build-configuration.patch
 
+# XCP-ng patches
+Patch1000: qemu-4.2.1-CVE-2023-3354.backport.patch
+
 BuildRequires: gcc
 BuildRequires: python2-devel
 BuildRequires: libaio-devel glib2-devel
@@ -198,6 +201,10 @@ cp -r scripts/qmp %{buildroot}%{_datarootdir}/qemu
 %{?_cov_results_package}
 
 %changelog
+* Tue Feb 11 2025 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 4.2.1-4.6.4.2
+- Add qemu-4.2.1-CVE-2023-3354.backport.patch to fix a CVE
+  of a NULL pointer dereference that can cause a DOS
+
 * Tue Jun 11 2024 Gael Duperrey <gduperrey@vates.tech> - 4.2.1-4.6.4.1
 - Sync to hotfix XS82ECU1068
 - *** Upstream changelog ***


### PR DESCRIPTION
In version 8.2 there is a NULL POINTER DEREFERENCE that can 
cause a DOS on qemu, which could block the visibility of a VM 
in XO for example or prevent access to a user on a VM.