### PR TITLE
Fix Server 2025 volatile write cache issue

### DIFF
--- a/SOURCES/0001-nvme-Don-t-check-NSID-in-NVME_VOLATILE_WRITE_CACHE.patch
+++ b/SOURCES/0001-nvme-Don-t-check-NSID-in-NVME_VOLATILE_WRITE_CACHE.patch
@@ -1,0 +1,105 @@
+From 7f975db63cba14b825ee453cc881f4a6ad364141 Mon Sep 17 00:00:00 2001
+From: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Date: Thu, 2 Oct 2025 19:30:42 +0200
+Subject: [PATCH] nvme: Don't check NSID in NVME_VOLATILE_WRITE_CACHE
+
+NVME_VOLATILE_WRITE_CACHE is a controller-level feature and therefore
+cannot be set per-namespace.
+
+However, current XCP-ng QEMU does it anyway, and returns
+NVME_INVALID_NSID if an "invalid" NSID (read: 0) is supplied.
+
+Unfortunately, Server 2025 storport and stornvme 10.0.26100.5074 cannot
+tolerate the error code of this feature being NVME_INVALID_NSID, and
+refuses to activate the namespaces.
+
+Note that each namespace has its own block backend with a different
+write cache state. While it's hard to keep track of individual backends'
+write cache states at initialization time, we can be conservative and
+announce that the write cache is always enabled at boot. Store an
+"ideal" state of the controller's write cache, and set all backend cache
+states to align with this value.
+
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+---
+ hw/block/nvme.c | 34 +++++++++++++++++++---------------
+ 1 file changed, 19 insertions(+), 15 deletions(-)
+
+diff --git a/hw/block/nvme.c b/hw/block/nvme.c
+index c69bc90..3a3e20d 100644
+--- a/hw/block/nvme.c
++++ b/hw/block/nvme.c
+@@ -1467,8 +1467,6 @@ static uint16_t nvme_get_feature(NvmeCtrl *n, NvmeCmd *cmd, NvmeRequest *req)
+     uint32_t dw11 = le32_to_cpu(cmd->cdw11);
+     uint32_t result;
+ 
+-    uint32_t nsid;
+-
+     trace_nvme_getfeat(dw10);
+ 
+     switch (dw10) {
+@@ -1485,13 +1483,7 @@ static uint16_t nvme_get_feature(NvmeCtrl *n, NvmeCmd *cmd, NvmeRequest *req)
+         result = cpu_to_le32(n->features.err_rec);
+         break;
+     case NVME_VOLATILE_WRITE_CACHE:
+-        nsid = le32_to_cpu(cmd->nsid);
+-        if (unlikely(nsid == 0 || nsid > n->num_namespaces)) {
+-            trace_nvme_err_invalid_ns(nsid, n->num_namespaces);
+-            return NVME_INVALID_NSID | NVME_DNR;
+-        }
+-
+-        result = blk_enable_write_cache(n->namespaces[nsid - 1]->conf.blk);
++        result = cpu_to_le32(n->features.volatile_wc);
+         trace_nvme_getfeat_vwcache(result ? "enabled" : "disabled");
+         break;
+     case NVME_NUMBER_OF_QUEUES:
+@@ -1548,7 +1540,9 @@ static uint16_t nvme_set_feature(NvmeCtrl *n, NvmeCmd *cmd, NvmeRequest *req)
+     uint32_t dw10 = le32_to_cpu(cmd->cdw10);
+     uint32_t dw11 = le32_to_cpu(cmd->cdw11);
+ 
+-    uint32_t nsid;
++    uint32_t i;
++    uint32_t volatile_wc;
++    NvmeNamespace *ns;
+ 
+     trace_nvme_setfeat(dw10, dw11);
+ 
+@@ -1561,13 +1555,22 @@ static uint16_t nvme_set_feature(NvmeCtrl *n, NvmeCmd *cmd, NvmeRequest *req)
+         }
+         break;
+     case NVME_VOLATILE_WRITE_CACHE:
+-        nsid = le32_to_cpu(cmd->nsid);
+-        if (unlikely(nsid == 0 || nsid > n->num_namespaces)) {
+-            trace_nvme_err_invalid_ns(nsid, n->num_namespaces);
+-            return NVME_INVALID_NSID | NVME_DNR;
++        volatile_wc = dw11 & 1;
++        n->features.volatile_wc = volatile_wc;
++
++        for (i = 0; i < n->num_namespaces; i++) {
++            ns = n->namespaces[i];
++            if (!ns) {
++                continue;
++            }
++
++            if (!volatile_wc && blk_enable_write_cache(ns->conf.blk)) {
++                blk_flush(ns->conf.blk);
++            }
++
++            blk_set_enable_write_cache(ns->conf.blk, volatile_wc);
+         }
+ 
+-        blk_set_enable_write_cache(n->namespaces[nsid - 1]->conf.blk, dw11 & 1);
+         break;
+     case NVME_NUMBER_OF_QUEUES:
+         if (n->qs_created > 2) {
+@@ -2355,6 +2358,7 @@ static void nvme_init_state(NvmeCtrl *n)
+     n->aer_reqs = g_new0(NvmeRequest *, NVME_AERL + 1);
+     n->temperature = NVME_TEMPERATURE;
+     n->features.temp_thresh = 0x14d;
++    n->features.volatile_wc = 1;
+     n->features.int_vector_config = g_malloc0_n(n->params.num_queues,
+         sizeof(*n->features.int_vector_config));
+ 
+-- 
+2.43.0
+

--- a/SPECS/qemu.spec
+++ b/SPECS/qemu.spec
@@ -15,7 +15,7 @@ Summary: qemu-dm device model
 Name: qemu
 Epoch: 2
 Version: 4.2.1
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPL
 Requires: xcp-clipboardd
 Requires: xengt-userspace
@@ -144,6 +144,7 @@ Patch116: msix_pba_log.patch
 
 # XCP-ng patches
 Patch1000: qemu-4.2.1-CVE-2023-3354.backport.patch
+Patch1001: 0001-nvme-Don-t-check-NSID-in-NVME_VOLATILE_WRITE_CACHE.patch
 
 BuildRequires: python3-devel
 BuildRequires: libaio-devel glib2-devel
@@ -231,11 +232,14 @@ cp -r scripts/qmp %{buildroot}%{_datarootdir}/qemu
 %{?_cov_results_package}
 
 %changelog
+* Thu Oct 02 2025 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.2.1-5.2.12.2
+- Fix Server 2025 issue with NVMe volatile write cache feature
+
 * Thu Feb 13 2025 Yann Dirson <yann.dirson@vates.tech> - 4.2.1-5.2.12.1
 - Sync with xs8 4.2.1-5.2.12, no code change, only rebuild against libjemalloc.so.2:
   * Fri Aug 02 2024 Stephen Cheng <stephen.cheng@cloud.com> - 4.2.1-5.2.12
   - CP-46112: Rebuild after new version of jemalloc
-  
+
   * Fri Aug 02 2024 Stephen Cheng <stephen.cheng@cloud.com> - 4.2.1-5.2.11
   - CP-46112: Rebuild with new version of jemalloc
 


### PR DESCRIPTION
Subject: [PATCH] nvme: Don't check NSID in NVME_VOLATILE_WRITE_CACHE

NVME_VOLATILE_WRITE_CACHE is a controller-level feature and therefore
cannot be set per-namespace.

However, current XCP-ng QEMU does it anyway, and returns
NVME_INVALID_NSID if an "invalid" NSID (read: 0) is supplied.

Unfortunately, in some unclear circumstances (e.g. after a fresh
installation; might be related to feature flags?), Server 2025 storport
and stornvme 10.0.26100.5074 cannot tolerate the error code of this
feature being NVME_INVALID_NSID, and refuses to activate the namespaces.

Note that each namespace has its own block backend with a different
write cache state. While it's hard to keep track of individual backends'
write cache states at initialization time, we can be conservative and
announce that the write cache is always enabled at boot. Store an
"ideal" state of the controller's write cache, and set all backend cache
states to align with this value.

Test checklist:
- [x] Scratch build + install
- [x] Confirm feature usage on Windows + Set Feature testing on Linux
- [x] Create test Windows image
- [ ] Create test Linux image?

---

### Work Item Reference

_If this change is related to a Vates internal task or issue, please provide a work item reference. Otherwise, leave this blank._

XCPNG-2427

Build: https://koji.xcp-ng.org/taskinfo?taskID=91464

---

### Why should this change be accepted as an update to XCP-ng?

_Explain the motivation, problem being solved, or benefit to users or maintainers._

Fixes a new BSOD with the Server 2025 September update.

Context: https://xcp-ng.org/forum/topic/11333/windows-2025-standard-24h2.11-iso-release-of-sept-25-crash-on-reboot-with-inaccessible-boot-device-0x7b-in-xcp-8.2.1-and-xcp-8.3

---

### Release Notes

#### Explain the change for users

_Write a user-facing explanation which will serve as a basis for public announcements._
_Good release notes explain what changes, who is concerned, and how it affects them. It's not a technical changelog._

- Fix BSODs on VMs having the Server 2025 September update and emulated NVMe controllers

#### Do users or support need to be aware of anything specific related to the update?

_Any manual steps, changes to default behavior, compatibility issues, etc._

- [ ] Yes
- [x] No

_If yes, provide details._

N/A

---

### Testing and regression avoidance

#### What tests have you done?

_1. Regarding the change itself._

- Tested on Server 2022 (not affected by the bug) and 2025 (with working QEMU fix)
- Inspected Linux kernel to find out it doesn't exercise this feature
- Manually tested the Set Feature command on Linux
- User testing in linked forum thread

_2. Regarding potential regressions._

- User testing in linked forum thread

#### What tests in current test suites cover this change?

_1. Regarding the change itself._

test_basic_without_ssh; tools-windows (pending image update); practically all Linux images contain the Xen PV block driver, and we don't have any images without

_2. Regarding potential regressions._

tools-windows

#### What tests were or will be added to CI for this change? If none, explain why.

_1. Regarding the change itself._

N/A (pending image update)

_2. To ensure there are no regressions._

N/A (not planned yet; I believe it's doable by just adding a new image)

#### What other tests should reviewers or testers perform (after the build)?

_1. Regarding the change itself._

Make sure Windows+Linux VM installation and booting works on UEFI without PV drivers

_2. Regarding potential regressions._

Same as above

---

### Documentation

#### Should existing documentation be updated, or new documentation be added?

- [ ] Yes
- [x] No

_If yes, explain what needs to be updated or added, and where. If no, explain why._

Bug fix only

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add features that could be useful for Xen Orchestra?

- [ ] Yes
- [x] No

_If yes, describe which features and how._

N/A