### PR TITLE
Backport fix for CVE-2021-3929

### DIFF
--- a/SOURCES/0001-hw-nvme-reenable-cqe-batching.patch
+++ b/SOURCES/0001-hw-nvme-reenable-cqe-batching.patch
@@ -1,0 +1,143 @@
+From 1861619b12bf27715ba73f9cacc46e5171e854cb Mon Sep 17 00:00:00 2001
+From: Klaus Jensen <k.jensen@samsung.com>
+Date: Wed, 19 Oct 2022 22:28:02 +0200
+Subject: [PATCH 1/7] hw/nvme: reenable cqe batching
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Commit 2e53b0b45024 ("hw/nvme: Use ioeventfd to handle doorbell
+updates") had the unintended effect of disabling batching of CQEs.
+
+This patch changes the sq/cq timers to bottom halfs and instead of
+calling nvme_post_cqes() immediately (causing an interrupt per cqe), we
+defer the call.
+
+                   | iops
+  -----------------+------
+    baseline       | 138k
+    +cqe batching  | 233k
+
+Fixes: 2e53b0b45024 ("hw/nvme: Use ioeventfd to handle doorbell updates")
+Reviewed-by: Keith Busch <kbusch@kernel.org>
+Reviewed-by: Jinhao Fan <fanjinhao21s@ict.ac.cn>
+Signed-off-by: Klaus Jensen <k.jensen@samsung.com>
+
+
+XCP-ng backport
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/d38cc6fd1cafc3f834bb529f79bfc23089e9e54f
+Notes:
+- Files moved from hw/block to hw/nvme in the original patch
+- Also removed timer_del() calls along with timer_free() ones to replace them
+  with qemu_bh_delete()
+---
+ hw/block/nvme.c | 20 ++++++++++----------
+ hw/block/nvme.h |  4 ++--
+ 2 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/hw/block/nvme.c b/hw/block/nvme.c
+index 02c7212..9ef12fb 100644
+--- a/hw/block/nvme.c
++++ b/hw/block/nvme.c
+@@ -41,6 +41,7 @@
+ #include "sysemu/block-backend.h"
+ #include "qapi/error.h"
+ 
++#include "qemu/main-loop.h"
+ #include "qemu/module.h"
+ #include "qemu/cutils.h"
+ #include "trace.h"
+@@ -771,7 +772,7 @@ static void nvme_enqueue_req_completion(NvmeCQueue *cq, NvmeRequest *req)
+     trace_nvme_enqueue_req_completion(req->cqe.cid, cq->cqid);
+     QTAILQ_REMOVE(&req->sq->out_req_list, req, entry);
+     QTAILQ_INSERT_TAIL(&cq->req_list, req, entry);
+-    timer_mod(cq->timer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + 500);
++    qemu_bh_schedule(cq->bh);
+ }
+ 
+ static void nvme_enqueue_event(NvmeCtrl *n, uint8_t event_type,
+@@ -1084,8 +1085,7 @@ static uint16_t nvme_io_cmd(NvmeCtrl *n, NvmeCmd *cmd, NvmeRequest *req)
+ static void nvme_free_sq(NvmeSQueue *sq, NvmeCtrl *n)
+ {
+     n->sq[sq->sqid] = NULL;
+-    timer_del(sq->timer);
+-    timer_free(sq->timer);
++    qemu_bh_delete(sq->bh);
+     g_free(sq->io_req);
+     if (sq->sqid) {
+         g_free(sq);
+@@ -1156,7 +1156,8 @@ static void nvme_init_sq(NvmeSQueue *sq, NvmeCtrl *n, uint64_t dma_addr,
+         QTAILQ_INIT(&(sq->io_req[i].blk_req_tailq));
+         QTAILQ_INSERT_TAIL(&(sq->req_list), &sq->io_req[i], entry);
+     }
+-    sq->timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, nvme_process_sq, sq);
++
++    sq->bh = qemu_bh_new(nvme_process_sq, sq);
+ 
+     assert(n->cq[cqid]);
+     cq = n->cq[cqid];
+@@ -1206,8 +1207,7 @@ static uint16_t nvme_create_sq(NvmeCtrl *n, NvmeCmd *cmd)
+ static void nvme_free_cq(NvmeCQueue *cq, NvmeCtrl *n)
+ {
+     n->cq[cq->cqid] = NULL;
+-    timer_del(cq->timer);
+-    timer_free(cq->timer);
++    qemu_bh_delete(cq->bh);
+     msix_vector_unuse(&n->parent_obj, cq->vector);
+     if (cq->cqid) {
+         g_free(cq);
+@@ -1252,7 +1252,7 @@ static void nvme_init_cq(NvmeCQueue *cq, NvmeCtrl *n, uint64_t dma_addr,
+     QTAILQ_INIT(&cq->sq_list);
+     msix_vector_use(&n->parent_obj, cq->vector);
+     n->cq[cqid] = cq;
+-    cq->timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, nvme_post_cqes, cq);
++    cq->bh = qemu_bh_new(nvme_post_cqes, cq);
+     n->qs_created++;
+ }
+ 
+@@ -2238,9 +2238,9 @@ static void nvme_process_db(NvmeCtrl *n, hwaddr addr, int val)
+         if (start_sqs) {
+             NvmeSQueue *sq;
+             QTAILQ_FOREACH(sq, &cq->sq_list, entry) {
+-                timer_mod(sq->timer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + 500);
++                qemu_bh_schedule(sq->bh);
+             }
+-            timer_mod(cq->timer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + 500);
++            qemu_bh_schedule(cq->bh);
+         }
+ 
+         if (cq->tail == cq->head) {
+@@ -2285,7 +2285,7 @@ static void nvme_process_db(NvmeCtrl *n, hwaddr addr, int val)
+         }
+ 
+         sq->tail = new_tail;
+-        timer_mod(sq->timer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + 500);
++        qemu_bh_schedule(sq->bh);
+     }
+ }
+ 
+diff --git a/hw/block/nvme.h b/hw/block/nvme.h
+index 6d2f7a4..8cab3df 100644
+--- a/hw/block/nvme.h
++++ b/hw/block/nvme.h
+@@ -67,7 +67,7 @@ typedef struct NvmeSQueue {
+     uint32_t    tail;
+     uint32_t    size;
+     uint64_t    dma_addr;
+-    QEMUTimer   *timer;
++    QEMUBH      *bh;
+     NvmeRequest *io_req;
+     QTAILQ_HEAD(, NvmeRequest) req_list;
+     QTAILQ_HEAD(, NvmeRequest) out_req_list;
+@@ -84,7 +84,7 @@ typedef struct NvmeCQueue {
+     uint32_t    vector;
+     uint32_t    size;
+     uint64_t    dma_addr;
+-    QEMUTimer   *timer;
++    QEMUBH      *bh;
+     QTAILQ_HEAD(, NvmeSQueue) sq_list;
+     QTAILQ_HEAD(, NvmeRequest) req_list;
+ } NvmeCQueue;
+-- 
+2.51.0
+

--- a/SOURCES/0002-util-async-add-a-human-readable-name-to-BHs-for-debu.patch
+++ b/SOURCES/0002-util-async-add-a-human-readable-name-to-BHs-for-debu.patch
@@ -1,0 +1,189 @@
+From 52599d99e735341759f86b69a28f314aaeb61229 Mon Sep 17 00:00:00 2001
+From: Stefan Hajnoczi <stefanha@redhat.com>
+Date: Wed, 14 Apr 2021 21:02:46 +0100
+Subject: [PATCH 2/7] util/async: add a human-readable name to BHs for
+ debugging
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+It can be difficult to debug issues with BHs in production environments.
+Although BHs can usually be identified by looking up their ->cb()
+function pointer, this requires debug information for the program. It is
+also not possible to print human-readable diagnostics about BHs because
+they have no identifier.
+
+This patch adds a name to each BH. The name is not unique per instance
+but differentiates between cb() functions, which is usually enough. It's
+done by changing aio_bh_new() and friends to macros that stringify cb.
+
+The next patch will use the name field when reporting leaked BHs.
+
+Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>
+Message-Id: <20210414200247.917496-2-stefanha@redhat.com>
+
+
+XCP-ng backport
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/0f08586c7171757d77c27ee6c606e8a1c44ac6e3
+Notes:
+- Minor patch offset changes
+---
+ include/block/aio.h       | 31 ++++++++++++++++++++++++++++---
+ include/qemu/main-loop.h  |  4 +++-
+ tests/ptimer-test-stubs.c |  2 +-
+ util/async.c              |  9 +++++++--
+ util/main-loop.c          |  4 ++--
+ 5 files changed, 41 insertions(+), 9 deletions(-)
+
+diff --git a/include/block/aio.h b/include/block/aio.h
+index 6b0d52f..2d8dc2e 100644
+--- a/include/block/aio.h
++++ b/include/block/aio.h
+@@ -190,20 +190,45 @@ void aio_context_acquire(AioContext *ctx);
+ /* Relinquish ownership of the AioContext. */
+ void aio_context_release(AioContext *ctx);
+ 
++/**
++ * aio_bh_schedule_oneshot_full: Allocate a new bottom half structure that will
++ * run only once and as soon as possible.
++ *
++ * @name: A human-readable identifier for debugging purposes.
++ */
++void aio_bh_schedule_oneshot_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
++                                  const char *name);
++
+ /**
+  * aio_bh_schedule_oneshot: Allocate a new bottom half structure that will run
+  * only once and as soon as possible.
++ *
++ * A convenience wrapper for aio_bh_schedule_oneshot_full() that uses cb as the
++ * name string.
+  */
+-void aio_bh_schedule_oneshot(AioContext *ctx, QEMUBHFunc *cb, void *opaque);
++#define aio_bh_schedule_oneshot(ctx, cb, opaque) \
++    aio_bh_schedule_oneshot_full((ctx), (cb), (opaque), (stringify(cb)))
+ 
+ /**
+- * aio_bh_new: Allocate a new bottom half structure.
++ * aio_bh_new_full: Allocate a new bottom half structure.
+  *
+  * Bottom halves are lightweight callbacks whose invocation is guaranteed
+  * to be wait-free, thread-safe and signal-safe.  The #QEMUBH structure
+  * is opaque and must be allocated prior to its use.
++ *
++ * @name: A human-readable identifier for debugging purposes.
++ */
++QEMUBH *aio_bh_new_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
++                        const char *name);
++
++/**
++ * aio_bh_new: Allocate a new bottom half structure
++ *
++ * A convenience wrapper for aio_bh_new_full() that uses the cb as the name
++ * string.
+  */
+-QEMUBH *aio_bh_new(AioContext *ctx, QEMUBHFunc *cb, void *opaque);
++#define aio_bh_new(ctx, cb, opaque) \
++    aio_bh_new_full((ctx), (cb), (opaque), (stringify(cb)))
+ 
+ /**
+  * aio_notify: Force processing of pending events.
+diff --git a/include/qemu/main-loop.h b/include/qemu/main-loop.h
+index f6ba78e..b131a0e 100644
+--- a/include/qemu/main-loop.h
++++ b/include/qemu/main-loop.h
+@@ -299,7 +299,9 @@ void qemu_mutex_unlock_iothread(void);
+ 
+ void qemu_fd_register(int fd);
+ 
+-QEMUBH *qemu_bh_new(QEMUBHFunc *cb, void *opaque);
++#define qemu_bh_new(cb, opaque) \
++    qemu_bh_new_full((cb), (opaque), (stringify(cb)))
++QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name);
+ void qemu_bh_schedule_idle(QEMUBH *bh);
+ 
+ enum {
+diff --git a/tests/ptimer-test-stubs.c b/tests/ptimer-test-stubs.c
+index ed393d9..d82970c 100644
+--- a/tests/ptimer-test-stubs.c
++++ b/tests/ptimer-test-stubs.c
+@@ -107,7 +107,7 @@ int64_t qemu_clock_deadline_ns_all(QEMUClockType type, int attr_mask)
+     return deadline;
+ }
+ 
+-QEMUBH *qemu_bh_new(QEMUBHFunc *cb, void *opaque)
++QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name)
+ {
+     QEMUBH *bh = g_new(QEMUBH, 1);
+ 
+diff --git a/util/async.c b/util/async.c
+index b1fa531..a9262f5 100644
+--- a/util/async.c
++++ b/util/async.c
+@@ -38,6 +38,7 @@
+ 
+ struct QEMUBH {
+     AioContext *ctx;
++    const char *name;
+     QEMUBHFunc *cb;
+     void *opaque;
+     QEMUBH *next;
+@@ -46,7 +47,8 @@ struct QEMUBH {
+     bool deleted;
+ };
+ 
+-void aio_bh_schedule_oneshot(AioContext *ctx, QEMUBHFunc *cb, void *opaque)
++void aio_bh_schedule_oneshot_full(AioContext *ctx, QEMUBHFunc *cb,
++                                  void *opaque, const char *name)
+ {
+     QEMUBH *bh;
+     bh = g_new(QEMUBH, 1);
+@@ -54,6 +56,7 @@ void aio_bh_schedule_oneshot(AioContext *ctx, QEMUBHFunc *cb, void *opaque)
+         .ctx = ctx,
+         .cb = cb,
+         .opaque = opaque,
++        .name = name,
+     };
+     qemu_lockcnt_lock(&ctx->list_lock);
+     bh->next = ctx->first_bh;
+@@ -66,7 +69,8 @@ void aio_bh_schedule_oneshot(AioContext *ctx, QEMUBHFunc *cb, void *opaque)
+     aio_notify(ctx);
+ }
+ 
+-QEMUBH *aio_bh_new(AioContext *ctx, QEMUBHFunc *cb, void *opaque)
++QEMUBH *aio_bh_new_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
++                        const char *name)
+ {
+     QEMUBH *bh;
+     bh = g_new(QEMUBH, 1);
+@@ -74,6 +78,7 @@ QEMUBH *aio_bh_new(AioContext *ctx, QEMUBHFunc *cb, void *opaque)
+         .ctx = ctx,
+         .cb = cb,
+         .opaque = opaque,
++        .name = name,
+     };
+     qemu_lockcnt_lock(&ctx->list_lock);
+     bh->next = ctx->first_bh;
+diff --git a/util/main-loop.c b/util/main-loop.c
+index eda63fe..04d0474 100644
+--- a/util/main-loop.c
++++ b/util/main-loop.c
+@@ -527,9 +527,9 @@ void main_loop_wait(int nonblocking)
+ 
+ /* Functions to operate on the main QEMU AioContext.  */
+ 
+-QEMUBH *qemu_bh_new(QEMUBHFunc *cb, void *opaque)
++QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name)
+ {
+-    return aio_bh_new(qemu_aio_context, cb, opaque);
++    return aio_bh_new_full(qemu_aio_context, cb, opaque, name);
+ }
+ 
+ /*
+-- 
+2.51.0
+

--- a/SOURCES/0003-memory-prevent-dma-reentracy-issues.patch
+++ b/SOURCES/0003-memory-prevent-dma-reentracy-issues.patch
@@ -1,0 +1,143 @@
+From 35364c2608a8dd31a8e44a00ae152f227934e2ed Mon Sep 17 00:00:00 2001
+From: Alexander Bulekov <alxndr@bu.edu>
+Date: Thu, 27 Apr 2023 17:10:06 -0400
+Subject: [PATCH 3/7] memory: prevent dma-reentracy issues
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Add a flag to the DeviceState, when a device is engaged in PIO/MMIO/DMA.
+This flag is set/checked prior to calling a device's MemoryRegion
+handlers, and set when device code initiates DMA.  The purpose of this
+flag is to prevent two types of DMA-based reentrancy issues:
+
+1.) mmio -> dma -> mmio case
+2.) bh -> dma write -> mmio case
+
+These issues have led to problems such as stack-exhaustion and
+use-after-frees.
+
+Summary of the problem from Peter Maydell:
+https://lore.kernel.org/qemu-devel/CAFEAcA_23vc7hE3iaM-JVA6W38LK4hJoWae5KcknhPRD5fPBZA@mail.gmail.com
+
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/62
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/540
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/541
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/556
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/557
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/827
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/1282
+Resolves: CVE-2023-0330
+
+Signed-off-by: Alexander Bulekov <alxndr@bu.edu>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Message-Id: <20230427211013.2994127-2-alxndr@bu.edu>
+[thuth: Replace warn_report() with warn_report_once()]
+Signed-off-by: Thomas Huth <thuth@redhat.com>
+(cherry picked from commit a2e1753b8054344f32cf94f31c6399a58794a380)
+Signed-off-by: Michael Tokarev <mjt@tls.msk.ru>
+
+
+XCP-ng backport
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/c40ca2301c7603524eaddb5308a3f524c6f89d24
+Notes:
+- Use of the error code MEMTX_ERROR instead of MEMTX_ACCESS_ERROR (not available
+  in Qemu 4.2.1) when a DMA-based reentrancy is detected.
+---
+ include/exec/memory.h  |  5 +++++
+ include/hw/qdev-core.h |  7 +++++++
+ memory.c               | 16 ++++++++++++++++
+ 3 files changed, 28 insertions(+)
+
+diff --git a/include/exec/memory.h b/include/exec/memory.h
+index e499dc2..3c520c6 100644
+--- a/include/exec/memory.h
++++ b/include/exec/memory.h
+@@ -378,6 +378,8 @@ struct MemoryRegion {
+     bool is_iommu;
+     RAMBlock *ram_block;
+     Object *owner;
++    /* owner as TYPE_DEVICE. Used for re-entrancy checks in MR access hotpath */
++    DeviceState *dev;
+ 
+     const MemoryRegionOps *ops;
+     void *opaque;
+@@ -400,6 +402,9 @@ struct MemoryRegion {
+     const char *name;
+     unsigned ioeventfd_nb;
+     MemoryRegionIoeventfd *ioeventfds;
++
++    /* For devices designed to perform re-entrant IO into their own IO MRs */
++    bool disable_reentrancy_guard;
+ };
+ 
+ struct IOMMUMemoryRegion {
+diff --git a/include/hw/qdev-core.h b/include/hw/qdev-core.h
+index 1518495..206f0a7 100644
+--- a/include/hw/qdev-core.h
++++ b/include/hw/qdev-core.h
+@@ -138,6 +138,10 @@ struct NamedGPIOList {
+     QLIST_ENTRY(NamedGPIOList) node;
+ };
+ 
++typedef struct {
++    bool engaged_in_io;
++} MemReentrancyGuard;
++
+ /**
+  * DeviceState:
+  * @realized: Indicates whether the device has been fully constructed.
+@@ -163,6 +167,9 @@ struct DeviceState {
+     int num_child_bus;
+     int instance_id_alias;
+     int alias_required_for_version;
++
++    /* Is the device currently in mmio/pio/dma? Used to prevent re-entrancy */
++    MemReentrancyGuard mem_reentrancy_guard;
+ };
+ 
+ struct DeviceListener {
+diff --git a/memory.c b/memory.c
+index 95eb3f6..5c5718a 100644
+--- a/memory.c
++++ b/memory.c
+@@ -531,6 +531,18 @@ static MemTxResult access_with_adjusted_size(hwaddr addr,
+         access_size_max = 4;
+     }
+ 
++    /* Do not allow more than one simultaneous access to a device's IO Regions */
++    if (mr->dev && !mr->disable_reentrancy_guard &&
++        !mr->ram_device && !mr->ram && !mr->rom_device && !mr->readonly) {
++        if (mr->dev->mem_reentrancy_guard.engaged_in_io) {
++            warn_report_once("Blocked re-entrant IO on MemoryRegion: "
++                             "%s at addr: 0x%" HWADDR_PRIX,
++                             memory_region_name(mr), addr);
++            return MEMTX_ERROR;
++        }
++        mr->dev->mem_reentrancy_guard.engaged_in_io = true;
++    }
++
+     /* FIXME: support unaligned access? */
+     access_size = MAX(MIN(size, access_size_max), access_size_min);
+     access_mask = MAKE_64BIT_MASK(0, access_size * 8);
+@@ -545,6 +557,9 @@ static MemTxResult access_with_adjusted_size(hwaddr addr,
+                         access_mask, attrs);
+         }
+     }
++    if (mr->dev) {
++        mr->dev->mem_reentrancy_guard.engaged_in_io = false;
++    }
+     return r;
+ }
+ 
+@@ -1132,6 +1147,7 @@ static void memory_region_do_init(MemoryRegion *mr,
+     }
+     mr->name = g_strdup(name);
+     mr->owner = owner;
++    mr->dev = (DeviceState *) object_dynamic_cast(mr->owner, TYPE_DEVICE);
+     mr->ram_block = NULL;
+ 
+     if (name) {
+-- 
+2.51.0
+

--- a/SOURCES/0004-async-Add-an-optional-reentrancy-guard-to-the-BH-API.patch
+++ b/SOURCES/0004-async-Add-an-optional-reentrancy-guard-to-the-BH-API.patch
@@ -1,0 +1,226 @@
+From 65f0a16882d287d51ffc96874a3dbc0605157a03 Mon Sep 17 00:00:00 2001
+From: Alexander Bulekov <alxndr@bu.edu>
+Date: Thu, 27 Apr 2023 17:10:07 -0400
+Subject: [PATCH 4/7] async: Add an optional reentrancy guard to the BH API
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Devices can pass their MemoryReentrancyGuard (from their DeviceState),
+when creating new BHes. Then, the async API will toggle the guard
+before/after calling the BH call-back. This prevents bh->mmio reentrancy
+issues.
+
+Signed-off-by: Alexander Bulekov <alxndr@bu.edu>
+Reviewed-by: Darren Kenny <darren.kenny@oracle.com>
+Message-Id: <20230427211013.2994127-3-alxndr@bu.edu>
+[thuth: Fix "line over 90 characters" checkpatch.pl error]
+Signed-off-by: Thomas Huth <thuth@redhat.com>
+(cherry picked from commit 9c86c97f12c060bf7484dd931f38634e166a81f0)
+Signed-off-by: Michael Tokarev <mjt@tls.msk.ru>
+[mjt: minor context adjustment in include/block/aio.h and include/qemu/main-loop.h for 7.2]
+
+
+XCP-ng backport
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/61dacb401bd375503863efda32678145fc9ceb55
+Notes:
+- Minor patch offset changes
+---
+ docs/devel/multiple-iothreads.txt |  7 +++++++
+ include/block/aio.h               | 18 ++++++++++++++++--
+ include/qemu/main-loop.h          |  7 +++++--
+ tests/ptimer-test-stubs.c         |  3 ++-
+ util/async.c                      | 18 +++++++++++++++++-
+ util/main-loop.c                  |  6 ++++--
+ util/trace-events                 |  1 +
+ 7 files changed, 52 insertions(+), 8 deletions(-)
+
+diff --git a/docs/devel/multiple-iothreads.txt b/docs/devel/multiple-iothreads.txt
+index aeb997b..a11576b 100644
+--- a/docs/devel/multiple-iothreads.txt
++++ b/docs/devel/multiple-iothreads.txt
+@@ -61,6 +61,7 @@ There are several old APIs that use the main loop AioContext:
+  * LEGACY qemu_aio_set_event_notifier() - monitor an event notifier
+  * LEGACY timer_new_ms() - create a timer
+  * LEGACY qemu_bh_new() - create a BH
++ * LEGACY qemu_bh_new_guarded() - create a BH with a device re-entrancy guard
+  * LEGACY qemu_aio_wait() - run an event loop iteration
+ 
+ Since they implicitly work on the main loop they cannot be used in code that
+@@ -72,8 +73,14 @@ Instead, use the AioContext functions directly (see include/block/aio.h):
+  * aio_set_event_notifier() - monitor an event notifier
+  * aio_timer_new() - create a timer
+  * aio_bh_new() - create a BH
++ * aio_bh_new_guarded() - create a BH with a device re-entrancy guard
+  * aio_poll() - run an event loop iteration
+ 
++The qemu_bh_new_guarded/aio_bh_new_guarded APIs accept a "MemReentrancyGuard"
++argument, which is used to check for and prevent re-entrancy problems. For
++BHs associated with devices, the reentrancy-guard is contained in the
++corresponding DeviceState and named "mem_reentrancy_guard".
++
+ The AioContext can be obtained from the IOThread using
+ iothread_get_aio_context() or for the main loop using qemu_get_aio_context().
+ Code that takes an AioContext argument works both in IOThreads or the main
+diff --git a/include/block/aio.h b/include/block/aio.h
+index 2d8dc2e..c145e11 100644
+--- a/include/block/aio.h
++++ b/include/block/aio.h
+@@ -18,6 +18,8 @@
+ #include "qemu/event_notifier.h"
+ #include "qemu/thread.h"
+ #include "qemu/timer.h"
++#include "hw/qdev-core.h"
++
+ 
+ typedef struct BlockAIOCB BlockAIOCB;
+ typedef void BlockCompletionFunc(void *opaque, int ret);
+@@ -217,9 +219,11 @@ void aio_bh_schedule_oneshot_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
+  * is opaque and must be allocated prior to its use.
+  *
+  * @name: A human-readable identifier for debugging purposes.
++ * @reentrancy_guard: A guard set when entering a cb to prevent
++ * device-reentrancy issues
+  */
+ QEMUBH *aio_bh_new_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
+-                        const char *name);
++                        const char *name, MemReentrancyGuard *reentrancy_guard);
+ 
+ /**
+  * aio_bh_new: Allocate a new bottom half structure
+@@ -228,7 +232,17 @@ QEMUBH *aio_bh_new_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
+  * string.
+  */
+ #define aio_bh_new(ctx, cb, opaque) \
+-    aio_bh_new_full((ctx), (cb), (opaque), (stringify(cb)))
++    aio_bh_new_full((ctx), (cb), (opaque), (stringify(cb)), NULL)
++
++/**
++ * aio_bh_new_guarded: Allocate a new bottom half structure with a
++ * reentrancy_guard
++ *
++ * A convenience wrapper for aio_bh_new_full() that uses the cb as the name
++ * string.
++ */
++#define aio_bh_new_guarded(ctx, cb, opaque, guard) \
++    aio_bh_new_full((ctx), (cb), (opaque), (stringify(cb)), guard)
+ 
+ /**
+  * aio_notify: Force processing of pending events.
+diff --git a/include/qemu/main-loop.h b/include/qemu/main-loop.h
+index b131a0e..cba048b 100644
+--- a/include/qemu/main-loop.h
++++ b/include/qemu/main-loop.h
+@@ -299,9 +299,12 @@ void qemu_mutex_unlock_iothread(void);
+ 
+ void qemu_fd_register(int fd);
+ 
++#define qemu_bh_new_guarded(cb, opaque, guard) \
++    qemu_bh_new_full((cb), (opaque), (stringify(cb)), guard)
+ #define qemu_bh_new(cb, opaque) \
+-    qemu_bh_new_full((cb), (opaque), (stringify(cb)))
+-QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name);
++    qemu_bh_new_full((cb), (opaque), (stringify(cb)), NULL)
++QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name,
++                         MemReentrancyGuard *reentrancy_guard);
+ void qemu_bh_schedule_idle(QEMUBH *bh);
+ 
+ enum {
+diff --git a/tests/ptimer-test-stubs.c b/tests/ptimer-test-stubs.c
+index d82970c..5da7222 100644
+--- a/tests/ptimer-test-stubs.c
++++ b/tests/ptimer-test-stubs.c
+@@ -107,7 +107,8 @@ int64_t qemu_clock_deadline_ns_all(QEMUClockType type, int attr_mask)
+     return deadline;
+ }
+ 
+-QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name)
++QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name,
++                         MemReentrancyGuard *reentrancy_guard)
+ {
+     QEMUBH *bh = g_new(QEMUBH, 1);
+ 
+diff --git a/util/async.c b/util/async.c
+index a9262f5..fe81c9d 100644
+--- a/util/async.c
++++ b/util/async.c
+@@ -45,6 +45,7 @@ struct QEMUBH {
+     bool scheduled;
+     bool idle;
+     bool deleted;
++    MemReentrancyGuard *reentrancy_guard;
+ };
+ 
+ void aio_bh_schedule_oneshot_full(AioContext *ctx, QEMUBHFunc *cb,
+@@ -70,7 +71,7 @@ void aio_bh_schedule_oneshot_full(AioContext *ctx, QEMUBHFunc *cb,
+ }
+ 
+ QEMUBH *aio_bh_new_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
+-                        const char *name)
++                        const char *name, MemReentrancyGuard *reentrancy_guard)
+ {
+     QEMUBH *bh;
+     bh = g_new(QEMUBH, 1);
+@@ -79,6 +80,7 @@ QEMUBH *aio_bh_new_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
+         .cb = cb,
+         .opaque = opaque,
+         .name = name,
++        .reentrancy_guard = reentrancy_guard,
+     };
+     qemu_lockcnt_lock(&ctx->list_lock);
+     bh->next = ctx->first_bh;
+@@ -91,7 +93,21 @@ QEMUBH *aio_bh_new_full(AioContext *ctx, QEMUBHFunc *cb, void *opaque,
+ 
+ void aio_bh_call(QEMUBH *bh)
+ {
++    bool last_engaged_in_io = false;
++
++    if (bh->reentrancy_guard) {
++        last_engaged_in_io = bh->reentrancy_guard->engaged_in_io;
++        if (bh->reentrancy_guard->engaged_in_io) {
++            trace_reentrant_aio(bh->ctx, bh->name);
++        }
++        bh->reentrancy_guard->engaged_in_io = true;
++    }
++
+     bh->cb(bh->opaque);
++
++    if (bh->reentrancy_guard) {
++        bh->reentrancy_guard->engaged_in_io = last_engaged_in_io;
++    }
+ }
+ 
+ /* Multiple occurrences of aio_bh_poll cannot be called concurrently.
+diff --git a/util/main-loop.c b/util/main-loop.c
+index 04d0474..96f0a26 100644
+--- a/util/main-loop.c
++++ b/util/main-loop.c
+@@ -527,9 +527,11 @@ void main_loop_wait(int nonblocking)
+ 
+ /* Functions to operate on the main QEMU AioContext.  */
+ 
+-QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name)
++QEMUBH *qemu_bh_new_full(QEMUBHFunc *cb, void *opaque, const char *name,
++                         MemReentrancyGuard *reentrancy_guard)
+ {
+-    return aio_bh_new_full(qemu_aio_context, cb, opaque, name);
++    return aio_bh_new_full(qemu_aio_context, cb, opaque, name,
++                           reentrancy_guard);
+ }
+ 
+ /*
+diff --git a/util/trace-events b/util/trace-events
+index 83b6639..0be714b 100644
+--- a/util/trace-events
++++ b/util/trace-events
+@@ -9,6 +9,7 @@ poll_grow(void *ctx, int64_t old, int64_t new) "ctx %p old %"PRId64" new %"PRId6
+ # async.c
+ aio_co_schedule(void *ctx, void *co) "ctx %p co %p"
+ aio_co_schedule_bh_cb(void *ctx, void *co) "ctx %p co %p"
++reentrant_aio(void *ctx, const char *name) "ctx %p name %s"
+ 
+ # thread-pool.c
+ thread_pool_submit(void *pool, void *req, void *opaque) "pool %p req %p opaque %p"
+-- 
+2.51.0
+

--- a/SOURCES/0005-async-avoid-use-after-free-on-re-entrancy-guard.patch
+++ b/SOURCES/0005-async-avoid-use-after-free-on-re-entrancy-guard.patch
@@ -1,0 +1,63 @@
+From 8235ccce3a6db8c11f11d09439d3a327ec629732 Mon Sep 17 00:00:00 2001
+From: Alexander Bulekov <alxndr@bu.edu>
+Date: Mon, 1 May 2023 10:19:56 -0400
+Subject: [PATCH 5/7] async: avoid use-after-free on re-entrancy guard
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+A BH callback can free the BH, causing a use-after-free in aio_bh_call.
+Fix that by keeping a local copy of the re-entrancy guard pointer.
+
+Buglink: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58513
+Fixes: 9c86c97f12 ("async: Add an optional reentrancy guard to the BH API")
+Signed-off-by: Alexander Bulekov <alxndr@bu.edu>
+Message-Id: <20230501141956.3444868-1-alxndr@bu.edu>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Signed-off-by: Thomas Huth <thuth@redhat.com>
+(cherry picked from commit 7915bd06f25e1803778081161bf6fa10c42dc7cd)
+Signed-off-by: Michael Tokarev <mjt@tls.msk.ru>
+
+
+XCP-ng backport
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/f88ebe0c7d05b242310110f91652d0fdb746d3c6
+Notes:
+- Minor patch offset changes
+---
+ util/async.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/util/async.c b/util/async.c
+index fe81c9d..d70ae22 100644
+--- a/util/async.c
++++ b/util/async.c
+@@ -95,18 +95,20 @@ void aio_bh_call(QEMUBH *bh)
+ {
+     bool last_engaged_in_io = false;
+ 
+-    if (bh->reentrancy_guard) {
+-        last_engaged_in_io = bh->reentrancy_guard->engaged_in_io;
+-        if (bh->reentrancy_guard->engaged_in_io) {
++    /* Make a copy of the guard-pointer as cb may free the bh */
++    MemReentrancyGuard *reentrancy_guard = bh->reentrancy_guard;
++    if (reentrancy_guard) {
++        last_engaged_in_io = reentrancy_guard->engaged_in_io;
++        if (reentrancy_guard->engaged_in_io) {
+             trace_reentrant_aio(bh->ctx, bh->name);
+         }
+-        bh->reentrancy_guard->engaged_in_io = true;
++        reentrancy_guard->engaged_in_io = true;
+     }
+ 
+     bh->cb(bh->opaque);
+ 
+-    if (bh->reentrancy_guard) {
+-        bh->reentrancy_guard->engaged_in_io = last_engaged_in_io;
++    if (reentrancy_guard) {
++        reentrancy_guard->engaged_in_io = last_engaged_in_io;
+     }
+ }
+ 
+-- 
+2.51.0
+

--- a/SOURCES/0006-hw-replace-most-qemu_bh_new-calls-with-qemu_bh_new_g.patch
+++ b/SOURCES/0006-hw-replace-most-qemu_bh_new-calls-with-qemu_bh_new_g.patch
@@ -1,0 +1,428 @@
+From 39d0fb3e7a0e8ad177cb81869af4af597c5ac754 Mon Sep 17 00:00:00 2001
+From: Alexander Bulekov <alxndr@bu.edu>
+Date: Thu, 27 Apr 2023 17:10:09 -0400
+Subject: [PATCH 6/7] hw: replace most qemu_bh_new calls with
+ qemu_bh_new_guarded
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+This protects devices from bh->mmio reentrancy issues.
+
+Thanks: Thomas Huth <thuth@redhat.com> for diagnosing OS X test failure.
+Signed-off-by: Alexander Bulekov <alxndr@bu.edu>
+Reviewed-by: Darren Kenny <darren.kenny@oracle.com>
+Reviewed-by: Stefan Hajnoczi <stefanha@redhat.com>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Reviewed-by: Paul Durrant <paul@xen.org>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Message-Id: <20230427211013.2994127-5-alxndr@bu.edu>
+Signed-off-by: Thomas Huth <thuth@redhat.com>
+(cherry picked from commit f63192b0544af5d3e4d5edfd85ab520fcf671377)
+Signed-off-by: Michael Tokarev <mjt@tls.msk.ru>
+
+
+XCP-ng backport
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/ae96dce3b79861f62a0d2068d2cd0511740a1a6d
+Notes:
+- File moved from hw/block/nvme.c to hw/nvme/ctrl.c in the original patch
+- Files hw/usb/hcd-dwc2.c and hw/misc/imx_rngc.c not yet present in 4.2.1
+---
+ hw/9pfs/xen-9p-backend.c        | 5 ++++-
+ hw/block/dataplane/virtio-blk.c | 3 ++-
+ hw/block/dataplane/xen-block.c  | 5 +++--
+ hw/block/nvme.c                 | 6 ++++--
+ hw/char/virtio-serial-bus.c     | 3 ++-
+ hw/display/qxl.c                | 9 ++++++---
+ hw/display/virtio-gpu.c         | 6 ++++--
+ hw/ide/ahci.c                   | 3 ++-
+ hw/ide/ahci_internal.h          | 1 +
+ hw/ide/core.c                   | 4 +++-
+ hw/misc/macio/mac_dbdma.c       | 2 +-
+ hw/net/virtio-net.c             | 3 ++-
+ hw/scsi/mptsas.c                | 3 ++-
+ hw/scsi/scsi-bus.c              | 3 ++-
+ hw/scsi/vmw_pvscsi.c            | 3 ++-
+ hw/usb/dev-uas.c                | 3 ++-
+ hw/usb/hcd-ehci.c               | 3 ++-
+ hw/usb/hcd-uhci.c               | 2 +-
+ hw/usb/host-libusb.c            | 6 ++++--
+ hw/usb/redirect.c               | 6 ++++--
+ hw/usb/xen-usb.c                | 3 ++-
+ hw/virtio/virtio-balloon.c      | 5 +++--
+ hw/virtio/virtio-crypto.c       | 3 ++-
+ 23 files changed, 60 insertions(+), 30 deletions(-)
+
+diff --git a/hw/9pfs/xen-9p-backend.c b/hw/9pfs/xen-9p-backend.c
+index de768f2..159404a 100644
+--- a/hw/9pfs/xen-9p-backend.c
++++ b/hw/9pfs/xen-9p-backend.c
+@@ -55,6 +55,7 @@ typedef struct Xen9pfsDev {
+ 
+     int num_rings;
+     Xen9pfsRing *rings;
++    MemReentrancyGuard mem_reentrancy_guard;
+ } Xen9pfsDev;
+ 
+ static void xen_9pfs_disconnect(struct XenLegacyDevice *xendev);
+@@ -435,7 +436,9 @@ static int xen_9pfs_connect(struct XenLegacyDevice *xendev)
+         xen_9pdev->rings[i].ring.out = xen_9pdev->rings[i].data +
+                                        XEN_FLEX_RING_SIZE(ring_order);
+ 
+-        xen_9pdev->rings[i].bh = qemu_bh_new(xen_9pfs_bh, &xen_9pdev->rings[i]);
++        xen_9pdev->rings[i].bh = qemu_bh_new_guarded(xen_9pfs_bh,
++                                                     &xen_9pdev->rings[i],
++                                                     &xen_9pdev->mem_reentrancy_guard);
+         xen_9pdev->rings[i].out_cons = 0;
+         xen_9pdev->rings[i].out_size = 0;
+         xen_9pdev->rings[i].inprogress = false;
+diff --git a/hw/block/dataplane/virtio-blk.c b/hw/block/dataplane/virtio-blk.c
+index 1b52e81..b16321f 100644
+--- a/hw/block/dataplane/virtio-blk.c
++++ b/hw/block/dataplane/virtio-blk.c
+@@ -127,7 +127,8 @@ bool virtio_blk_data_plane_create(VirtIODevice *vdev, VirtIOBlkConf *conf,
+     } else {
+         s->ctx = qemu_get_aio_context();
+     }
+-    s->bh = aio_bh_new(s->ctx, notify_guest_bh, s);
++    s->bh = aio_bh_new_guarded(s->ctx, notify_guest_bh, s,
++                               &DEVICE(vdev)->mem_reentrancy_guard);
+     s->batch_notify_vqs = bitmap_new(conf->num_queues);
+ 
+     *dataplane = s;
+diff --git a/hw/block/dataplane/xen-block.c b/hw/block/dataplane/xen-block.c
+index c4ed287..ffee69c 100644
+--- a/hw/block/dataplane/xen-block.c
++++ b/hw/block/dataplane/xen-block.c
+@@ -631,8 +631,9 @@ XenBlockDataPlane *xen_block_dataplane_create(XenDevice *xendev,
+     } else {
+         dataplane->ctx = qemu_get_aio_context();
+     }
+-    dataplane->bh = aio_bh_new(dataplane->ctx, xen_block_dataplane_bh,
+-                               dataplane);
++    dataplane->bh = aio_bh_new_guarded(dataplane->ctx, xen_block_dataplane_bh,
++                                       dataplane,
++                                       &DEVICE(xendev)->mem_reentrancy_guard);
+ 
+     return dataplane;
+ }
+diff --git a/hw/block/nvme.c b/hw/block/nvme.c
+index 9ef12fb..541b636 100644
+--- a/hw/block/nvme.c
++++ b/hw/block/nvme.c
+@@ -1157,7 +1157,8 @@ static void nvme_init_sq(NvmeSQueue *sq, NvmeCtrl *n, uint64_t dma_addr,
+         QTAILQ_INSERT_TAIL(&(sq->req_list), &sq->io_req[i], entry);
+     }
+ 
+-    sq->bh = qemu_bh_new(nvme_process_sq, sq);
++    sq->bh = qemu_bh_new_guarded(nvme_process_sq, sq,
++                                 &DEVICE(sq->ctrl)->mem_reentrancy_guard);
+ 
+     assert(n->cq[cqid]);
+     cq = n->cq[cqid];
+@@ -1252,7 +1253,8 @@ static void nvme_init_cq(NvmeCQueue *cq, NvmeCtrl *n, uint64_t dma_addr,
+     QTAILQ_INIT(&cq->sq_list);
+     msix_vector_use(&n->parent_obj, cq->vector);
+     n->cq[cqid] = cq;
+-    cq->bh = qemu_bh_new(nvme_post_cqes, cq);
++    cq->bh = qemu_bh_new_guarded(nvme_post_cqes, cq,
++                                 &DEVICE(cq->ctrl)->mem_reentrancy_guard);
+     n->qs_created++;
+ }
+ 
+diff --git a/hw/char/virtio-serial-bus.c b/hw/char/virtio-serial-bus.c
+index 3325904..3d2a433 100644
+--- a/hw/char/virtio-serial-bus.c
++++ b/hw/char/virtio-serial-bus.c
+@@ -943,7 +943,8 @@ static void virtser_port_device_realize(DeviceState *dev, Error **errp)
+     Error *err = NULL;
+ 
+     port->vser = bus->vser;
+-    port->bh = qemu_bh_new(flush_queued_data_bh, port);
++    port->bh = qemu_bh_new_guarded(flush_queued_data_bh, port,
++                                   &dev->mem_reentrancy_guard);
+ 
+     assert(vsc->have_data);
+ 
+diff --git a/hw/display/qxl.c b/hw/display/qxl.c
+index cd7eb39..65ad661 100644
+--- a/hw/display/qxl.c
++++ b/hw/display/qxl.c
+@@ -2201,11 +2201,14 @@ static void qxl_realize_common(PCIQXLDevice *qxl, Error **errp)
+ 
+     qemu_add_vm_change_state_handler(qxl_vm_change_state_handler, qxl);
+ 
+-    qxl->update_irq = qemu_bh_new(qxl_update_irq_bh, qxl);
++    qxl->update_irq = qemu_bh_new_guarded(qxl_update_irq_bh, qxl,
++                                          &DEVICE(qxl)->mem_reentrancy_guard);
+     qxl_reset_state(qxl);
+ 
+-    qxl->update_area_bh = qemu_bh_new(qxl_render_update_area_bh, qxl);
+-    qxl->ssd.cursor_bh = qemu_bh_new(qemu_spice_cursor_refresh_bh, &qxl->ssd);
++    qxl->update_area_bh = qemu_bh_new_guarded(qxl_render_update_area_bh, qxl,
++                                              &DEVICE(qxl)->mem_reentrancy_guard);
++    qxl->ssd.cursor_bh = qemu_bh_new_guarded(qemu_spice_cursor_refresh_bh, &qxl->ssd,
++                                             &DEVICE(qxl)->mem_reentrancy_guard);
+ }
+ 
+ static void qxl_realize_primary(PCIDevice *dev, Error **errp)
+diff --git a/hw/display/virtio-gpu.c b/hw/display/virtio-gpu.c
+index 28e868c..f624389 100644
+--- a/hw/display/virtio-gpu.c
++++ b/hw/display/virtio-gpu.c
+@@ -1131,8 +1131,10 @@ static void virtio_gpu_device_realize(DeviceState *qdev, Error **errp)
+ 
+     g->ctrl_vq = virtio_get_queue(vdev, 0);
+     g->cursor_vq = virtio_get_queue(vdev, 1);
+-    g->ctrl_bh = qemu_bh_new(virtio_gpu_ctrl_bh, g);
+-    g->cursor_bh = qemu_bh_new(virtio_gpu_cursor_bh, g);
++    g->ctrl_bh = qemu_bh_new_guarded(virtio_gpu_ctrl_bh, g,
++                                     &qdev->mem_reentrancy_guard);
++    g->cursor_bh = qemu_bh_new_guarded(virtio_gpu_cursor_bh, g,
++                                       &qdev->mem_reentrancy_guard);
+     QTAILQ_INIT(&g->reslist);
+     QTAILQ_INIT(&g->cmdq);
+     QTAILQ_INIT(&g->fenceq);
+diff --git a/hw/ide/ahci.c b/hw/ide/ahci.c
+index d45393c..5f08122 100644
+--- a/hw/ide/ahci.c
++++ b/hw/ide/ahci.c
+@@ -1502,7 +1502,8 @@ static void ahci_cmd_done(IDEDMA *dma)
+     ahci_write_fis_d2h(ad);
+ 
+     if (ad->port_regs.cmd_issue && !ad->check_bh) {
+-        ad->check_bh = qemu_bh_new(ahci_check_cmd_bh, ad);
++        ad->check_bh = qemu_bh_new_guarded(ahci_check_cmd_bh, ad,
++                                           &ad->mem_reentrancy_guard);
+         qemu_bh_schedule(ad->check_bh);
+     }
+ }
+diff --git a/hw/ide/ahci_internal.h b/hw/ide/ahci_internal.h
+index 7342451..93e8c89 100644
+--- a/hw/ide/ahci_internal.h
++++ b/hw/ide/ahci_internal.h
+@@ -321,6 +321,7 @@ struct AHCIDevice {
+     bool init_d2h_sent;
+     AHCICmdHdr *cur_cmd;
+     NCQTransferState ncq_tfs[AHCI_MAX_CMDS];
++    MemReentrancyGuard mem_reentrancy_guard;
+ };
+ 
+ struct AHCIPCIState {
+diff --git a/hw/ide/core.c b/hw/ide/core.c
+index 6f762da..8693d50 100644
+--- a/hw/ide/core.c
++++ b/hw/ide/core.c
+@@ -502,11 +502,13 @@ BlockAIOCB *ide_issue_trim(
+         BlockCompletionFunc *cb, void *cb_opaque, void *opaque)
+ {
+     IDEState *s = opaque;
++    IDEDevice *dev = s->unit ? s->bus->slave : s->bus->master;
+     TrimAIOCB *iocb;
+ 
+     iocb = blk_aio_get(&trim_aiocb_info, s->blk, cb, cb_opaque);
+     iocb->s = s;
+-    iocb->bh = qemu_bh_new(ide_trim_bh_cb, iocb);
++    iocb->bh = qemu_bh_new_guarded(ide_trim_bh_cb, iocb,
++                                   &DEVICE(dev)->mem_reentrancy_guard);
+     iocb->ret = 0;
+     iocb->qiov = qiov;
+     iocb->i = -1;
+diff --git a/hw/misc/macio/mac_dbdma.c b/hw/misc/macio/mac_dbdma.c
+index e220f1a..f6a9e76 100644
+--- a/hw/misc/macio/mac_dbdma.c
++++ b/hw/misc/macio/mac_dbdma.c
+@@ -912,7 +912,7 @@ static void mac_dbdma_realize(DeviceState *dev, Error **errp)
+ {
+     DBDMAState *s = MAC_DBDMA(dev);
+ 
+-    s->bh = qemu_bh_new(DBDMA_run_bh, s);
++    s->bh = qemu_bh_new_guarded(DBDMA_run_bh, s, &dev->mem_reentrancy_guard);
+ }
+ 
+ static void mac_dbdma_class_init(ObjectClass *oc, void *data)
+diff --git a/hw/net/virtio-net.c b/hw/net/virtio-net.c
+index f325440..83ecf37 100644
+--- a/hw/net/virtio-net.c
++++ b/hw/net/virtio-net.c
+@@ -2362,7 +2362,8 @@ static void virtio_net_add_queue(VirtIONet *n, int index)
+         n->vqs[index].tx_vq =
+             virtio_add_queue(vdev, n->net_conf.tx_queue_size,
+                              virtio_net_handle_tx_bh);
+-        n->vqs[index].tx_bh = qemu_bh_new(virtio_net_tx_bh, &n->vqs[index]);
++        n->vqs[index].tx_bh = qemu_bh_new_guarded(virtio_net_tx_bh, &n->vqs[index],
++                                                  &DEVICE(vdev)->mem_reentrancy_guard);
+     }
+ 
+     n->vqs[index].tx_waiting = 0;
+diff --git a/hw/scsi/mptsas.c b/hw/scsi/mptsas.c
+index b8a4b37..bb58312 100644
+--- a/hw/scsi/mptsas.c
++++ b/hw/scsi/mptsas.c
+@@ -1321,7 +1321,8 @@ static void mptsas_scsi_realize(PCIDevice *dev, Error **errp)
+     }
+     s->max_devices = MPTSAS_NUM_PORTS;
+ 
+-    s->request_bh = qemu_bh_new(mptsas_fetch_requests, s);
++    s->request_bh = qemu_bh_new_guarded(mptsas_fetch_requests, s,
++                                        &DEVICE(dev)->mem_reentrancy_guard);
+ 
+     QTAILQ_INIT(&s->pending);
+ 
+diff --git a/hw/scsi/scsi-bus.c b/hw/scsi/scsi-bus.c
+index ad0e7f6..20b8101 100644
+--- a/hw/scsi/scsi-bus.c
++++ b/hw/scsi/scsi-bus.c
+@@ -155,7 +155,8 @@ static void scsi_dma_restart_cb(void *opaque, int running, RunState state)
+     }
+     if (!s->bh) {
+         AioContext *ctx = blk_get_aio_context(s->conf.blk);
+-        s->bh = aio_bh_new(ctx, scsi_dma_restart_bh, s);
++        s->bh = aio_bh_new_guarded(ctx, scsi_dma_restart_bh, s,
++                                   &DEVICE(s)->mem_reentrancy_guard);
+         qemu_bh_schedule(s->bh);
+     }
+ }
+diff --git a/hw/scsi/vmw_pvscsi.c b/hw/scsi/vmw_pvscsi.c
+index 452a3b6..5034b8a 100644
+--- a/hw/scsi/vmw_pvscsi.c
++++ b/hw/scsi/vmw_pvscsi.c
+@@ -1141,7 +1141,8 @@ pvscsi_realizefn(PCIDevice *pci_dev, Error **errp)
+         pcie_endpoint_cap_init(pci_dev, PVSCSI_EXP_EP_OFFSET);
+     }
+ 
+-    s->completion_worker = qemu_bh_new(pvscsi_process_completion_queue, s);
++    s->completion_worker = qemu_bh_new_guarded(pvscsi_process_completion_queue, s,
++                                               &DEVICE(pci_dev)->mem_reentrancy_guard);
+ 
+     scsi_bus_new(&s->bus, sizeof(s->bus), DEVICE(pci_dev),
+                  &pvscsi_scsi_info, NULL);
+diff --git a/hw/usb/dev-uas.c b/hw/usb/dev-uas.c
+index 6d6d107..5a6d443 100644
+--- a/hw/usb/dev-uas.c
++++ b/hw/usb/dev-uas.c
+@@ -914,7 +914,8 @@ static void usb_uas_realize(USBDevice *dev, Error **errp)
+ 
+     QTAILQ_INIT(&uas->results);
+     QTAILQ_INIT(&uas->requests);
+-    uas->status_bh = qemu_bh_new(usb_uas_send_status_bh, uas);
++    uas->status_bh = qemu_bh_new_guarded(usb_uas_send_status_bh, uas,
++                                         &d->mem_reentrancy_guard);
+ 
+     scsi_bus_new(&uas->bus, sizeof(uas->bus), DEVICE(dev),
+                  &usb_uas_scsi_info, NULL);
+diff --git a/hw/usb/hcd-ehci.c b/hw/usb/hcd-ehci.c
+index b8143e5..e151855 100644
+--- a/hw/usb/hcd-ehci.c
++++ b/hw/usb/hcd-ehci.c
+@@ -2527,7 +2527,8 @@ void usb_ehci_realize(EHCIState *s, DeviceState *dev, Error **errp)
+     }
+ 
+     s->frame_timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, ehci_work_timer, s);
+-    s->async_bh = qemu_bh_new(ehci_work_bh, s);
++    s->async_bh = qemu_bh_new_guarded(ehci_work_bh, s,
++                                      &dev->mem_reentrancy_guard);
+     s->device = dev;
+ 
+     s->vmstate = qemu_add_vm_change_state_handler(usb_ehci_vm_state_change, s);
+diff --git a/hw/usb/hcd-uhci.c b/hw/usb/hcd-uhci.c
+index 9c345ac..7ef7a62 100644
+--- a/hw/usb/hcd-uhci.c
++++ b/hw/usb/hcd-uhci.c
+@@ -1246,7 +1246,7 @@ static void usb_uhci_common_realize(PCIDevice *dev, Error **errp)
+                               USB_SPEED_MASK_LOW | USB_SPEED_MASK_FULL);
+         }
+     }
+-    s->bh = qemu_bh_new(uhci_bh, s);
++    s->bh = qemu_bh_new_guarded(uhci_bh, s, &DEVICE(dev)->mem_reentrancy_guard);
+     s->frame_timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, uhci_frame_timer, s);
+     s->num_ports_vmstate = NB_PORTS;
+     QTAILQ_INIT(&s->queues);
+diff --git a/hw/usb/host-libusb.c b/hw/usb/host-libusb.c
+index fcf48c0..4b09970 100644
+--- a/hw/usb/host-libusb.c
++++ b/hw/usb/host-libusb.c
+@@ -983,7 +983,8 @@ static void usb_host_nodev_bh(void *opaque)
+ static void usb_host_nodev(USBHostDevice *s)
+ {
+     if (!s->bh_nodev) {
+-        s->bh_nodev = qemu_bh_new(usb_host_nodev_bh, s);
++        s->bh_nodev = qemu_bh_new_guarded(usb_host_nodev_bh, s,
++                                          &DEVICE(s)->mem_reentrancy_guard);
+     }
+     qemu_bh_schedule(s->bh_nodev);
+ }
+@@ -1562,7 +1563,8 @@ static int usb_host_post_load(void *opaque, int version_id)
+     USBHostDevice *dev = opaque;
+ 
+     if (!dev->bh_postld) {
+-        dev->bh_postld = qemu_bh_new(usb_host_post_load_bh, dev);
++        dev->bh_postld = qemu_bh_new_guarded(usb_host_post_load_bh, dev,
++                                             &DEVICE(dev)->mem_reentrancy_guard);
+     }
+     qemu_bh_schedule(dev->bh_postld);
+     dev->bh_postld_pending = true;
+diff --git a/hw/usb/redirect.c b/hw/usb/redirect.c
+index e0f5ca6..430280f 100644
+--- a/hw/usb/redirect.c
++++ b/hw/usb/redirect.c
+@@ -1419,8 +1419,10 @@ static void usbredir_realize(USBDevice *udev, Error **errp)
+         }
+     }
+ 
+-    dev->chardev_close_bh = qemu_bh_new(usbredir_chardev_close_bh, dev);
+-    dev->device_reject_bh = qemu_bh_new(usbredir_device_reject_bh, dev);
++    dev->chardev_close_bh = qemu_bh_new_guarded(usbredir_chardev_close_bh, dev,
++                                                &DEVICE(dev)->mem_reentrancy_guard);
++    dev->device_reject_bh = qemu_bh_new_guarded(usbredir_device_reject_bh, dev,
++                                                &DEVICE(dev)->mem_reentrancy_guard);
+     dev->attach_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL, usbredir_do_attach, dev);
+ 
+     packet_id_queue_init(&dev->cancelled, dev, "cancelled");
+diff --git a/hw/usb/xen-usb.c b/hw/usb/xen-usb.c
+index 1fc2f32..b8bace2 100644
+--- a/hw/usb/xen-usb.c
++++ b/hw/usb/xen-usb.c
+@@ -1025,7 +1025,8 @@ static void usbback_alloc(struct XenLegacyDevice *xendev)
+ 
+     QTAILQ_INIT(&usbif->req_free_q);
+     QSIMPLEQ_INIT(&usbif->hotplug_q);
+-    usbif->bh = qemu_bh_new(usbback_bh, usbif);
++    usbif->bh = qemu_bh_new_guarded(usbback_bh, usbif,
++                                    &DEVICE(xendev)->mem_reentrancy_guard);
+ }
+ 
+ static int usbback_free(struct XenLegacyDevice *xendev)
+diff --git a/hw/virtio/virtio-balloon.c b/hw/virtio/virtio-balloon.c
+index 9762a65..ec6a372 100644
+--- a/hw/virtio/virtio-balloon.c
++++ b/hw/virtio/virtio-balloon.c
+@@ -807,8 +807,9 @@ static void virtio_balloon_device_realize(DeviceState *dev, Error **errp)
+         precopy_add_notifier(&s->free_page_report_notify);
+ 
+         object_ref(OBJECT(s->iothread));
+-        s->free_page_bh = aio_bh_new(iothread_get_aio_context(s->iothread),
+-                                     virtio_ballloon_get_free_page_hints, s);
++        s->free_page_bh = aio_bh_new_guarded(iothread_get_aio_context(s->iothread),
++                                             virtio_ballloon_get_free_page_hints, s,
++                                             &dev->mem_reentrancy_guard);
+     }
+     reset_stats(s);
+ }
+diff --git a/hw/virtio/virtio-crypto.c b/hw/virtio/virtio-crypto.c
+index b2e01fc..93fb975 100644
+--- a/hw/virtio/virtio-crypto.c
++++ b/hw/virtio/virtio-crypto.c
+@@ -807,7 +807,8 @@ static void virtio_crypto_device_realize(DeviceState *dev, Error **errp)
+         vcrypto->vqs[i].dataq =
+                  virtio_add_queue(vdev, 1024, virtio_crypto_handle_dataq_bh);
+         vcrypto->vqs[i].dataq_bh =
+-                 qemu_bh_new(virtio_crypto_dataq_bh, &vcrypto->vqs[i]);
++                 qemu_bh_new_guarded(virtio_crypto_dataq_bh, &vcrypto->vqs[i],
++                                     &dev->mem_reentrancy_guard);
+         vcrypto->vqs[i].vcrypto = vcrypto;
+     }
+ 
+-- 
+2.51.0
+

--- a/SOURCES/0007-apic-disable-reentrancy-detection-for-apic-msi.patch
+++ b/SOURCES/0007-apic-disable-reentrancy-detection-for-apic-msi.patch
@@ -1,0 +1,48 @@
+From bff52dccb9d5ca260c5cc8c940d008df71f6b094 Mon Sep 17 00:00:00 2001
+From: Alexander Bulekov <alxndr@bu.edu>
+Date: Thu, 27 Apr 2023 17:10:13 -0400
+Subject: [PATCH 7/7] apic: disable reentrancy detection for apic-msi
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+As the code is designed for re-entrant calls to apic-msi, mark apic-msi
+as reentrancy-safe.
+
+Signed-off-by: Alexander Bulekov <alxndr@bu.edu>
+Reviewed-by: Darren Kenny <darren.kenny@oracle.com>
+Message-Id: <20230427211013.2994127-9-alxndr@bu.edu>
+Signed-off-by: Thomas Huth <thuth@redhat.com>
+(cherry picked from commit 50795ee051a342c681a9b45671c552fbd6274db8)
+Signed-off-by: Michael Tokarev <mjt@tls.msk.ru>
+
+
+XCP-ng backport
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/79873ecad01a10f1809e31121bd9a2eb461d60de
+Notes:
+- Minor patch offset changes
+---
+ hw/intc/apic.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/hw/intc/apic.c b/hw/intc/apic.c
+index 2a74f7b..71c296f 100644
+--- a/hw/intc/apic.c
++++ b/hw/intc/apic.c
+@@ -894,6 +894,13 @@ static void apic_realize(DeviceState *dev, Error **errp)
+     memory_region_init_io(&s->io_memory, OBJECT(s), &apic_io_ops, s, "apic-msi",
+                           APIC_SPACE_SIZE);
+ 
++    /*
++     * apic-msi's apic_mem_write can call into ioapic_eoi_broadcast, which can
++     * write back to apic-msi. As such mark the apic-msi region re-entrancy
++     * safe.
++     */
++    s->io_memory.disable_reentrancy_guard = true;
++
+     s->timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, apic_timer, s);
+     local_apics[s->id] = s;
+ 
+-- 
+2.51.0
+

--- a/SPECS/qemu.spec
+++ b/SPECS/qemu.spec
@@ -15,7 +15,7 @@ Summary: qemu-dm device model
 Name: qemu
 Epoch: 2
 Version: 4.2.1
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPL
 Requires: xcp-clipboardd
 Requires: xengt-userspace
@@ -146,6 +146,13 @@ Patch118: msix_pba_log.patch
 
 # XCP-ng patches
 Patch1000: qemu-4.2.1-CVE-2023-3354.backport.patch
+Patch1001: 0001-hw-nvme-reenable-cqe-batching.patch
+Patch1002: 0002-util-async-add-a-human-readable-name-to-BHs-for-debu.patch
+Patch1003: 0003-memory-prevent-dma-reentracy-issues.patch
+Patch1004: 0004-async-Add-an-optional-reentrancy-guard-to-the-BH-API.patch
+Patch1005: 0005-async-avoid-use-after-free-on-re-entrancy-guard.patch
+Patch1006: 0006-hw-replace-most-qemu_bh_new-calls-with-qemu_bh_new_g.patch
+Patch1007: 0007-apic-disable-reentrancy-detection-for-apic-msi.patch
 
 BuildRequires: python3-devel
 BuildRequires: libaio-devel glib2-devel
@@ -233,6 +240,9 @@ cp -r scripts/qmp %{buildroot}%{_datarootdir}/qemu
 %{?_cov_results_package}
 
 %changelog
+* Thu Jan 08 2026 Thierry Escande <thierry.escande@vates.tech> - 4.2.1-5.2.15.2
+- Backport fixes for CVE-2021-3929
+
 * Mon Dec 08 2025 Tu Dinh <ngoc-tu.dinh@vates.tech> - 4.2.1-5.2.15.1
 - Sync with 4.2.1-5.2.15
 - *** Upstream changelog ***


### PR DESCRIPTION
This change backports the upstream patches that fixes CVE-2021-3929. This includes DMA-based reentrancy issues fix as well as reentrancy guard added to the bottom halfs (BH) APIs.

In order for these patches to apply correctly, 2 other patches have been backported concerning sq/cq timers changed to BH in nvme code and readable name field added to BH structures and APIs.

The issue was reproducible by following the steps described [here](https://gitlab.com/qemu-project/qemu/-/issues/782) by enabling 'with_asan = 1' in the spec file, add support for Q35 and ISAPC in i386-softmmu.mak file, and select PCSPK in hw/i386/Kconfig.