### PR TITLE
Add virtio-vga support

### DIFF
--- a/SOURCES/enable-virtio-vga.patch
+++ b/SOURCES/enable-virtio-vga.patch
@@ -1,0 +1,16 @@
+Enable compiling virtio-vga/gpu support.
+
+Signed-off-by: Teddy Astie <teddy.astie@vates.tech>
+---
+Bug-Vates: XCPNG-1332
+---
+diff --git a/default-configs/i386-softmmu.mak b/default-configs/i386-softmmu.mak
+--- a/default-configs/i386-softmmu.mak
++++ b/default-configs/i386-softmmu.mak
+@@ -54,3 +54,6 @@
+ CONFIG_USB_UHCI=y
+ CONFIG_VGA_CIRRUS=y
+ CONFIG_VGA_PCI=y
++CONFIG_VIRTIO_PCI=y
++CONFIG_VIRTIO_GPU=y
++CONFIG_VIRTIO_VGA=y

--- a/SOURCES/virtio-vga-0001-hw-virtio-Introduce-virtio_bh_new_guarded-helper.patch
+++ b/SOURCES/virtio-vga-0001-hw-virtio-Introduce-virtio_bh_new_guarded-helper.patch
@@ -1,0 +1,72 @@
+From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@linaro.org>
+Date: Thu, 4 Apr 2024 20:56:11 +0200
+Subject: [PATCH 1/2] hw/virtio: Introduce virtio_bh_new_guarded() helper
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Introduce virtio_bh_new_guarded(), similar to qemu_bh_new_guarded()
+but using the transport memory guard, instead of the device one
+(there can only be one virtio device per virtio bus).
+
+Inspired-by: Gerd Hoffmann <kraxel@redhat.com>
+Reviewed-by: Gerd Hoffmann <kraxel@redhat.com>
+Acked-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Philippe Mathieu-Daudé <philmd@linaro.org>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Message-Id: <20240409105537.18308-2-philmd@linaro.org>
+
+Backported-by: Teddy Astie <teddy.astie@vates.tech>
+---
+Origin: https://github.com/qemu/qemu/commit/ec0504b989ca61e03636384d3602b7bf07ffe4da
+Bug-Vates: XCPNG-1332
+---
+ hw/virtio/virtio.c         | 10 ++++++++++
+ include/hw/virtio/virtio.h |  8 ++++++++
+ 2 files changed, 18 insertions(+)
+
+diff --git a/hw/virtio/virtio.c b/hw/virtio/virtio.c
+index 6c71141ed1..c2dd27fad9 100644
+--- a/hw/virtio/virtio.c
++++ b/hw/virtio/virtio.c
+@@ -3806,3 +3806,13 @@ static void virtio_register_types(void)
+ }
+ 
+ type_init(virtio_register_types)
++
++QEMUBH *virtio_bh_new_guarded_full(DeviceState *dev,
++                                   QEMUBHFunc *cb, void *opaque,
++                                   const char *name)
++{
++    DeviceState *transport = qdev_get_parent_bus(dev)->parent;
++
++    return qemu_bh_new_full(cb, opaque, name,
++                            &transport->mem_reentrancy_guard);
++}
+diff --git a/include/hw/virtio/virtio.h b/include/hw/virtio/virtio.h
+index e18756d50d..30f5f539a8 100644
+--- a/include/hw/virtio/virtio.h
++++ b/include/hw/virtio/virtio.h
+@@ -21,6 +21,7 @@
+ #include "qemu/event_notifier.h"
+ #include "standard-headers/linux/virtio_config.h"
+ #include "standard-headers/linux/virtio_ring.h"
++#include "block/aio.h"
+ 
+ /* A guest should never accept this.  It implies negotiation is broken. */
+ #define VIRTIO_F_BAD_FEATURE		30
+@@ -380,4 +381,11 @@ static inline void virtio_set_started(VirtIODevice *vdev, bool started)
+         vdev->started = started;
+     }
+ }
++
++QEMUBH *virtio_bh_new_guarded_full(DeviceState *dev,
++                                   QEMUBHFunc *cb, void *opaque,
++                                   const char *name);
++#define virtio_bh_new_guarded(dev, cb, opaque) \
++    virtio_bh_new_guarded_full((dev), (cb), (opaque), (stringify(cb)))
++
+ #endif
+-- 
+2.52.0
+

--- a/SOURCES/virtio-vga-0002-hw-display-virtio-gpu-Protect-from-DMA-re-entrancy-b.patch
+++ b/SOURCES/virtio-vga-0002-hw-display-virtio-gpu-Protect-from-DMA-re-entrancy-b.patch
@@ -1,0 +1,145 @@
+From: =?UTF-8?q?Philippe=20Mathieu-Daud=C3=A9?= <philmd@linaro.org>
+Date: Thu, 4 Apr 2024 20:56:27 +0200
+Subject: [PATCH 2/2] hw/display/virtio-gpu: Protect from DMA re-entrancy bugs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Replace qemu_bh_new_guarded() by virtio_bh_new_guarded()
+so the bus and device use the same guard. Otherwise the
+DMA-reentrancy protection can be bypassed:
+
+  $ cat << EOF | qemu-system-i386 -display none -nodefaults \
+                                  -machine q35,accel=qtest \
+                                  -m 512M \
+                                  -device virtio-gpu \
+                                  -qtest stdio
+  outl 0xcf8 0x80000820
+  outl 0xcfc 0xe0004000
+  outl 0xcf8 0x80000804
+  outw 0xcfc 0x06
+  write 0xe0004030 0x4 0x024000e0
+  write 0xe0004028 0x1 0xff
+  write 0xe0004020 0x4 0x00009300
+  write 0xe000401c 0x1 0x01
+  write 0x101 0x1 0x04
+  write 0x103 0x1 0x1c
+  write 0x9301c8 0x1 0x18
+  write 0x105 0x1 0x1c
+  write 0x107 0x1 0x1c
+  write 0x109 0x1 0x1c
+  write 0x10b 0x1 0x00
+  write 0x10d 0x1 0x00
+  write 0x10f 0x1 0x00
+  write 0x111 0x1 0x00
+  write 0x113 0x1 0x00
+  write 0x115 0x1 0x00
+  write 0x117 0x1 0x00
+  write 0x119 0x1 0x00
+  write 0x11b 0x1 0x00
+  write 0x11d 0x1 0x00
+  write 0x11f 0x1 0x00
+  write 0x121 0x1 0x00
+  write 0x123 0x1 0x00
+  write 0x125 0x1 0x00
+  write 0x127 0x1 0x00
+  write 0x129 0x1 0x00
+  write 0x12b 0x1 0x00
+  write 0x12d 0x1 0x00
+  write 0x12f 0x1 0x00
+  write 0x131 0x1 0x00
+  write 0x133 0x1 0x00
+  write 0x135 0x1 0x00
+  write 0x137 0x1 0x00
+  write 0x139 0x1 0x00
+  write 0xe0007003 0x1 0x00
+  EOF
+  ...
+  =================================================================
+  ==276099==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d000011178
+  at pc 0x562cc3b736c7 bp 0x7ffed49dee60 sp 0x7ffed49dee58
+  READ of size 8 at 0x60d000011178 thread T0
+      #0 0x562cc3b736c6 in virtio_gpu_ctrl_response hw/display/virtio-gpu.c:180:42
+      #1 0x562cc3b7c40b in virtio_gpu_ctrl_response_nodata hw/display/virtio-gpu.c:192:5
+      #2 0x562cc3b7c40b in virtio_gpu_simple_process_cmd hw/display/virtio-gpu.c:1015:13
+      #3 0x562cc3b82873 in virtio_gpu_process_cmdq hw/display/virtio-gpu.c:1050:9
+      #4 0x562cc4a85514 in aio_bh_call util/async.c:169:5
+      #5 0x562cc4a85c52 in aio_bh_poll util/async.c:216:13
+      #6 0x562cc4a1a79b in aio_dispatch util/aio-posix.c:423:5
+      #7 0x562cc4a8a2da in aio_ctx_dispatch util/async.c:358:5
+      #8 0x7f36840547a8 in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x547a8)
+      #9 0x562cc4a8b753 in glib_pollfds_poll util/main-loop.c:290:9
+      #10 0x562cc4a8b753 in os_host_main_loop_wait util/main-loop.c:313:5
+      #11 0x562cc4a8b753 in main_loop_wait util/main-loop.c:592:11
+      #12 0x562cc3938186 in qemu_main_loop system/runstate.c:782:9
+      #13 0x562cc43b7af5 in qemu_default_main system/main.c:37:14
+      #14 0x7f3683a6c189 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
+      #15 0x7f3683a6c244 in __libc_start_main csu/../csu/libc-start.c:381:3
+      #16 0x562cc2a58ac0 in _start (qemu-system-i386+0x231bac0)
+
+  0x60d000011178 is located 56 bytes inside of 136-byte region [0x60d000011140,0x60d0000111c8)
+  freed by thread T0 here:
+      #0 0x562cc2adb662 in __interceptor_free (qemu-system-i386+0x239e662)
+      #1 0x562cc3b86b21 in virtio_gpu_reset hw/display/virtio-gpu.c:1524:9
+      #2 0x562cc416e20e in virtio_reset hw/virtio/virtio.c:2145:9
+      #3 0x562cc37c5644 in virtio_pci_reset hw/virtio/virtio-pci.c:2249:5
+      #4 0x562cc4233758 in memory_region_write_accessor system/memory.c:497:5
+      #5 0x562cc4232eea in access_with_adjusted_size system/memory.c:573:18
+
+  previously allocated by thread T0 here:
+      #0 0x562cc2adb90e in malloc (qemu-system-i386+0x239e90e)
+      #1 0x7f368405a678 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5a678)
+      #2 0x562cc4163ffc in virtqueue_split_pop hw/virtio/virtio.c:1612:12
+      #3 0x562cc4163ffc in virtqueue_pop hw/virtio/virtio.c:1783:16
+      #4 0x562cc3b91a95 in virtio_gpu_handle_ctrl hw/display/virtio-gpu.c:1112:15
+      #5 0x562cc4a85514 in aio_bh_call util/async.c:169:5
+      #6 0x562cc4a85c52 in aio_bh_poll util/async.c:216:13
+      #7 0x562cc4a1a79b in aio_dispatch util/aio-posix.c:423:5
+
+  SUMMARY: AddressSanitizer: heap-use-after-free hw/display/virtio-gpu.c:180:42 in virtio_gpu_ctrl_response
+
+With this change, the same reproducer triggers:
+
+  qemu-system-i386: warning: Blocked re-entrant IO on MemoryRegion: virtio-pci-common-virtio-gpu at addr: 0x6
+
+Fixes: CVE-2024-3446
+Cc: qemu-stable@nongnu.org
+Reported-by: Alexander Bulekov <alxndr@bu.edu>
+Reported-by: Yongkang Jia <kangel@zju.edu.cn>
+Reported-by: Xiao Lei <nop.leixiao@gmail.com>
+Reported-by: Yiming Tao <taoym@zju.edu.cn>
+Buglink: https://bugs.launchpad.net/qemu/+bug/1888606
+Reviewed-by: Gerd Hoffmann <kraxel@redhat.com>
+Acked-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Philippe Mathieu-Daudé <philmd@linaro.org>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Message-Id: <20240409105537.18308-3-philmd@linaro.org>
+
+Backported-by: Teddy Astie <teddy.astie@vates.tech>
+---
+Origin: https://github.com/qemu/qemu/commit/ba28e0ff4d95b56dc334aac2730ab3651ffc3132
+Bug-Vates: XCPNG-1332
+---
+ hw/display/virtio-gpu.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/hw/display/virtio-gpu.c b/hw/display/virtio-gpu.c
+index f624389b82..c57d68a471 100644
+--- a/hw/display/virtio-gpu.c
++++ b/hw/display/virtio-gpu.c
+@@ -1131,10 +1131,8 @@ static void virtio_gpu_device_realize(DeviceState *qdev, Error **errp)
+ 
+     g->ctrl_vq = virtio_get_queue(vdev, 0);
+     g->cursor_vq = virtio_get_queue(vdev, 1);
+-    g->ctrl_bh = qemu_bh_new_guarded(virtio_gpu_ctrl_bh, g,
+-                                     &qdev->mem_reentrancy_guard);
+-    g->cursor_bh = qemu_bh_new_guarded(virtio_gpu_cursor_bh, g,
+-                                       &qdev->mem_reentrancy_guard);
++    g->ctrl_bh = virtio_bh_new_guarded(qdev, virtio_gpu_ctrl_bh, g);
++    g->cursor_bh = virtio_bh_new_guarded(qdev, virtio_gpu_cursor_bh, g);
+     QTAILQ_INIT(&g->reslist);
+     QTAILQ_INIT(&g->cmdq);
+     QTAILQ_INIT(&g->fenceq);
+-- 
+2.52.0
+

--- a/SPECS/qemu.spec
+++ b/SPECS/qemu.spec
@@ -15,7 +15,7 @@ Summary: qemu-dm device model
 Name: qemu
 Epoch: 2
 Version: 4.2.1
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: GPL
 Requires: xcp-clipboardd
 Requires: xengt-userspace
@@ -153,6 +153,10 @@ Patch1004: 0004-async-Add-an-optional-reentrancy-guard-to-the-BH-API.patch
 Patch1005: 0005-async-avoid-use-after-free-on-re-entrancy-guard.patch
 Patch1006: 0006-hw-replace-most-qemu_bh_new-calls-with-qemu_bh_new_g.patch
 Patch1007: 0007-apic-disable-reentrancy-detection-for-apic-msi.patch
+# virtio-vga support
+Patch1008: virtio-vga-0001-hw-virtio-Introduce-virtio_bh_new_guarded-helper.patch
+Patch1009: virtio-vga-0002-hw-display-virtio-gpu-Protect-from-DMA-re-entrancy-b.patch
+Patch1010: enable-virtio-vga.patch
 
 BuildRequires: python3-devel
 BuildRequires: libaio-devel glib2-devel
@@ -240,6 +244,9 @@ cp -r scripts/qmp %{buildroot}%{_datarootdir}/qemu
 %{?_cov_results_package}
 
 %changelog
+* Mon Jan 26 2026 Teddy Astie <teddy.astie@vates.tech> - 4.2.1-5.2.15.3
+- Add virtio-vga support
+
 * Thu Jan 08 2026 Thierry Escande <thierry.escande@vates.tech> - 4.2.1-5.2.15.2
 - Backport fixes for CVE-2021-3929
 


### PR DESCRIPTION
Add support for virtio-vga device (as a alternative to cirrus or "VGA").

TODO:
* test if it works (it should)
* test if CVE-2024-3446 is actually fixed

Needs https://github.com/xcp-ng-rpms/xapi/commit/b4e7d6555ef0fc47a3a45d5464a92fb307a6af17